### PR TITLE
Moved login logic into triggerable method

### DIFF
--- a/index.js
+++ b/index.js
@@ -167,10 +167,10 @@ class Multicolour_Auth_JWT {
             password: request.payload.email,
             callback: (err, session) => {
               if (err) {
-                return get_decorator_for_apply_value(reply, method)(err, models.multicolour_user);//.code(err.code || 500)
+                return get_decorator_for_apply_value(reply, method)(err, models.multicolour_user).code(err.code || 500)
               }
 
-              get_decorator_for_apply_value(reply, method)(session, models.session);//.code(202)
+              get_decorator_for_apply_value(reply, method)(session, models.session).code(202)
             }
           }
 

--- a/index.js
+++ b/index.js
@@ -65,6 +65,7 @@ class Multicolour_Auth_JWT {
         else {
           // Hash the password.
           mc_utils.hash_password(password, user.salt, hashed_password => {
+
             if (user.password !== hashed_password) {
               return callback(new Error(ERROR_INVALID_USERNAME));
             }
@@ -136,8 +137,11 @@ class Multicolour_Auth_JWT {
 
       server.auth.strategy("jwt", "jwt", {
         key: config.password,
-        validateFunc: (decoded, request, callback) =>
-          this.validate(host, decoded, callback),
+        validateFunc: (decoded, request, callback) => {
+          // TODO: Redirect when not requesting JSON
+
+          this.validate(host, decoded, callback)
+        },
         verifyOptions: {
           algorithms: config.algorithms || [ "HS256" ]
         }

--- a/index.js
+++ b/index.js
@@ -64,8 +64,14 @@ class Multicolour_Auth_JWT {
         }
         // We're good to create a session.
         else {
+
           // Hash the password.
           mc_utils.hash_password(password, user.salt, hashed_password => {
+// console.log(user.salt);
+// console.log(password);
+// console.log(hashed_password);
+// console.log(user.password);
+
             if (user.password !== hashed_password) {
               return callback(new Error(ERROR_INVALID_USERNAME))
             }
@@ -128,6 +134,9 @@ class Multicolour_Auth_JWT {
       const password = args.password
       const callback = args.callback ? args.callback : _ => {}
 
+console.log(args, password);
+
+
       this.auth(identifier, password, callback, identifier_field)
     })
 
@@ -165,7 +174,7 @@ class Multicolour_Auth_JWT {
           const method = request.headers.accept
           const args = {
             email: request.payload.email.toString(),
-            password: request.payload.email,
+            password: request.payload.password,
             callback: (err, session) => {
               if (err) {
                 return get_decorator_for_apply_value(reply, method)(err, models.multicolour_user).code(err.code || 500)

--- a/index.js
+++ b/index.js
@@ -67,10 +67,6 @@ class Multicolour_Auth_JWT {
 
           // Hash the password.
           mc_utils.hash_password(password, user.salt, hashed_password => {
-// console.log(user.salt);
-// console.log(password);
-// console.log(hashed_password);
-// console.log(user.password);
 
             if (user.password !== hashed_password) {
               return callback(new Error(ERROR_INVALID_USERNAME))
@@ -133,9 +129,6 @@ class Multicolour_Auth_JWT {
       const identifier = args[identifier_field]
       const password = args.password
       const callback = args.callback ? args.callback : _ => {}
-
-console.log(args, password);
-
 
       this.auth(identifier, password, callback, identifier_field)
     })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "multicolour-hapi-jwt",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "JWT Auth plugin for HapiJS Multicolour",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,9 @@
     "authentication"
   ],
   "author": "newworldcode <hello@newworld.codes> (https://newworld.codes)",
+  "contributors": [
+    {"name": "Adam Cowley", "url": "http://www.adamcowley.co.uk"}
+  ],
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/newworldcode/multicolour-auth-jwt/issues"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "multicolour-hapi-jwt",
-  "version": "0.1.2",
+  "version": "0.1.1",
   "description": "JWT Auth plugin for HapiJS Multicolour",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
I've moved the code from inside the route into a triggerable handler that can be used across the Multicolour environment.  For example:

```
 server.route({
      method: "POST",
      path: "/login",
      config: {
        auth: false,
      },
      handler: (request, reply) => {
        const args = {
          email: request.payload.email.toString(),
          password: request.payload.password,
          callback: (err, session) => {
            const redirect_to = request.query.redirect || '/';
            const cookieKey = config.cookieKey || DEFAULT_COOKIE_TOKEN;

            if (err) {
              return reply.redirect(`/login?redirect=${encodeUriComponent(redirect_to)}&error=true`);
            }

            // Apply Redirect
            reply.redirect(redirect_to)
              // Set Cookie as per jwt2 docs so we can pick it up in the front end
              .state(cookieKey, session.token)
          }
        }

        generator.trigger('auth_login', args);
      }
    })
  }
```